### PR TITLE
Add Sass support

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -215,7 +215,7 @@ module.exports = async function newProject(name, options, leek) {
       ['commands', 'options', 'parent'].indexOf(opt) === -1) {
       cliConfig[opt] = options[opt];
   }
-  
+
   cliConfig['apps'] = [clientName, serverName];
   cliConfig['disableAnalytics'] = false;
 }
@@ -270,6 +270,14 @@ module.exports = async function newProject(name, options, leek) {
 
   process.stdout.write('ember-cli ');
   await spawnPromise('ember', emberArgs, { stdio: 'inherit', env: process.env });
+
+  // Install compass and sass
+  var addonArgs = ['install:addon', 'ember-cli-compass-compiler'];
+  process.stdout.write('ember-cli ');
+  process.chdir(path.join(clientName, 'app'));
+  await spawnPromise('ember', addonArgs, { stdio: 'inherit', env: process.env });
+  await spawnPromise('mv', ['./styles/app.css', './styles/client.scss'], { stdio: 'inherit', env: process.env });
+  process.chdir('../../');
 
   //copy over template files
   var templates = getTemplates(projectMeta.sanePath());


### PR DESCRIPTION
Projects will be generated with ember-cli-compass-compiler, providing support for Sass and Compass. The app/styles/app.css is renamed to app/styles/client.scss (client.scss because it compiles to client.css, which is referenced in the index.html file). Any other Sass files in app/styles will be compiled, but you should (obviously) import them into client.scss instead of importing their css output directly.