### PR TITLE
Add support for longer Ember version strings

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -183,7 +183,7 @@ module.exports = async function newProject(name, options, leek) {
     ember = 'ember';
     //compare the different ember versions
     //slices out only the version number from global ember:
-    var emberVersion = exec(`${ember} version`, { silent: true }).output.slice(9, 14);
+    var emberVersion = exec(`${ember} version`, { silent: true }).output.slice(9, 16).trim();
     // var localEmberVersion = exec(`${localEmber} version`, { silent: true }).output
     // var globalEmber = path.relative(process.cwd(), path.join(exec('npm root -g', { silent: true }).output, 'ember-cli', 'package.json'));
     // var emberVersion = require(globalEmber).version;


### PR DESCRIPTION
Ember version "0.1.11" was being sliced down to "0.1.1"
Added support for 2 more characters and trimmed off any trailing whitespace.