### PR TITLE
Switch to babel.

### DIFF
--- a/bin/sane
+++ b/bin/sane
@@ -7,7 +7,7 @@ process.title = 'sane';
 var path = require('path');
 var resolve = require('resolve');
 
-require("6to5/register")({
+require('babel/register')({
   experimental: true
 });
 

--- a/bin/sane
+++ b/bin/sane
@@ -7,18 +7,9 @@ process.title = 'sane';
 var path = require('path');
 var resolve = require('resolve');
 
-//transforms all following require's to parse ES6/7 code
-require('traceur').require.makeDefault(function(filename) {
-  // don't transpile our dependencies, just our app
-  //The first check is if you develop locally, the second for the globally installed module
-  if (filename.indexOf('bin/sane') > -1) {
-    return false;
-  }
-  //The first check is if you develop locally, the second for the globally installed moduel
-  return (filename.indexOf('node_modules') === -1) ||
-    (filename.indexOf(path.join('node_modules', 'sane-cli')) > -1 &&
-      filename.indexOf(path.join('node_modules', 'sane-cli', 'node_modules')) === -1);
-}, {asyncFunctions: true});
+require("6to5/register")({
+  experimental: true
+});
 
 var cli;
 resolve('sane-cli', {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "http://sanestack.com",
   "dependencies": {
-    "6to5": "^3.5.3",
+    "6to5": "^3.6.0",
     "chalk": "^0.5.1",
     "child-process-promise": "^1.0.1",
     "commander": "~2.6.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "http://sanestack.com",
   "dependencies": {
-    "6to5": "^3.6.0",
+    "babel": "^4.3.0",
     "chalk": "^0.5.1",
     "child-process-promise": "^1.0.1",
     "commander": "~2.6.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "homepage": "http://sanestack.com",
   "dependencies": {
+    "6to5": "^3.5.3",
     "chalk": "^0.5.1",
     "child-process-promise": "^1.0.1",
     "commander": "~2.6.0",
@@ -52,7 +53,6 @@
     "resolve": "^1.0.0",
     "shelljs": "~0.3.0",
     "superspawn": "^0.1.0",
-    "traceur": "0.0.82",
     "walk-sync": "~0.1.3",
     "yam": "0.0.17"
   },

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -3,13 +3,10 @@
 var glob = require('glob');
 var Mocha = require('mocha');
 
+require("6to5/register")({
+  experimental: true
+});
 
-require('traceur').require.makeDefault(function(filename) {
-// don't transpile our dependencies, just our app
-//The first check is if you develop locally, the second for the globally installed moduel
-  return (filename.indexOf('node_modules') === -1) ||
-    (filename.indexOf('/node_modules/sane-cli/') > -1 && filename.indexOf('/node_modules/sane-cli/node_modules') === -1);
-}, {asyncFunctions: true});
 
 var mocha = new Mocha({
   timeout: 18000,

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -3,13 +3,20 @@
 var glob = require('glob');
 var Mocha = require('mocha');
 
-require("6to5/register")({
+require("babel/register")({
   experimental: true
 });
 
+var timeout = 18000;
+
+if (process.platform === 'win32') {
+  //apparently windows is taking its time...
+  //Well yeah look into performance improvements.
+  timeout = 90000;
+}
 
 var mocha = new Mocha({
-  timeout: 18000,
+  timeout: timeout,
   reporter: 'spec'
 });
 


### PR DESCRIPTION
Require times compared to [traceur](https://github.com/google/traceur-compiler) seem now roughly the same. Will probably merge in once the latest optimizations https://github.com/6to5/6to5/pull/743 will be released.