### PR TITLE
Fix 'sane new --skip-npm'

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -21,7 +21,7 @@ var getAppNames = require('../tasks/getAppNames');
 
 var serverName = getAppNames.server();
 var clientName = getAppNames.client();
-
+var progress = new PleasantProgress();
 
 function normalizeOption(option) {
   if (option === 'mongodb') {
@@ -283,7 +283,6 @@ module.exports = async function newProject(name, options, leek) {
   await dockerExec('sails new .', options.docker);
 
   if (!options.skipNpm) {
-    var progress = new PleasantProgress();
     progress.start(chalk.green('Installing Sails packages for tooling via npm.'));
   }
 
@@ -339,8 +338,9 @@ module.exports = async function newProject(name, options, leek) {
   }
 
   await cleanUpSails(options, silent);
-
-  await spawnPromise('npm', ['install'], { env: process.env });
+  if (!options.skipNpm) {
+    await spawnPromise('npm', ['install'], { env: process.env });
+  }
 
   progress.stop();
   console.log(chalk.green('Sane Project \'' + projectName + '\' successfully created.'));


### PR DESCRIPTION
If --skip-npm option was used, progress is not defined which would
then fail when using it for "Running tooling scripts for Sane."

Also, npm install was being run at the very end regardless of --skip-npm option