### PR TITLE
attempt to fix appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
     # appveyor doesn't know what node 0.12.0 is, don't test with node for now.
     #- nodejs_version: "0.12.0"
     # io.js 1.x
-    - nodejs_version: "1"
+    - nodejs_version: "1.5.0"
 
 platform:
   - x64


### PR DESCRIPTION
when appveyor sees `nodejs_version: "1"` it attempts to install the latest iojs which it probably doesn't have in it's package repository.  Attempt setting it to "1.5.0", and see if it has that one.