### PR TITLE
[ENHANCEMENT] Show error stack trace on `sane new`

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -48,9 +48,11 @@ module.exports = function cli(args) {
   .option('--skip-npm [boolean]', 'Skips npm installation for ember-cli project creation', config.skipNpm || false)
   .option('--skip-bower [boolean]', 'Skips bower installation for ember-cli project creation', config.skipBower || false)
   .action(function (name, options) {
-    commands.new(name, options, leek).catch(function (error) {
-      console.log(chalk.red(error.message));
-    });
+    commands.new(name, options, leek)
+      .catch(function (error) {
+        console.log(chalk.red(error.message));
+        console.log(error.stack);
+      });
   });
 
   program


### PR DESCRIPTION
If the verbose option is set, return the stack trace,
otherwise, simply disply a red error message.