### PR TITLE
[BUGFIX] Disallow use of local ember-cli in Windows

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -208,13 +208,21 @@ module.exports = async function newProject(name, options, leek) {
 
     //compare the different ember versions
     if ( emberVersion !== localEmberVersion) {
-      var answer = question(chalk.gray(
-        `Detected different versions for sane's locally installed ` +
-        `ember-cli (${localEmberVersion}) and your ` +
-        `global one (${emberVersion}).\n` +
-        `Want to use sane's local Ember? (y/n):`) + '  (y) ') || 'y';
-      if (answer === 'y' || answer === 'Y') {
-        ember = localEmber;
+      // Not possible to use locally installed ember-cli on Windows (no .cmd file)
+      if (process.platform === 'win32') {
+        console.log(chalk.yellow(`Warning: Detected different versions for sane's locally installed ` +
+          `ember-cli (${localEmberVersion}) and your ` +
+          `global one (${emberVersion}).\n` +
+          `Using your global version.`));
+      } else {
+        var answer = question(chalk.gray(
+          `Detected different versions for sane's locally installed ` +
+          `ember-cli (${localEmberVersion}) and your ` +
+          `global one (${emberVersion}).\n` +
+          `Want to use sane's local Ember? (y/n):`) + '  (y) ') || 'y';
+        if (answer === 'y' || answer === 'Y') {
+          ember = localEmber;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #128

The local `node_module` package of ember-cli does not
contain the necessary .cmd batch file for Windows to execute.

Therefore, it's necessary to use the user's globally installed
ember-cli version.