### PR TITLE
[BUGFIX] Fix npm install of sails-hook-dev

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -340,7 +340,7 @@ module.exports = async function newProject(name, options, leek) {
   }
 
   var sailsPackages = ['sails-generate-ember-blueprints', 'lodash', 'pluralize',
-  'sails-hook-autoreload@~0.11.4', 'balderdashy/sails-hook-dev', `sails-${options.database}`];
+    'sails-hook-autoreload@~0.11.4', 'sails-hook-dev@balderdashy/sails-hook-dev', `sails-${options.database}`];
   await dockerExec(`npm i ${sailsPackages.join(' ')} --save`, options.docker, silent, options.skipNpm);
   await dockerExec('sails generate ember-blueprints', options.docker, silent, options.skipNpm);
 


### PR DESCRIPTION
Until a new 1.0.1 version of sails-hook-dev is released, need to use the balderdashy repo.  It was incorrectly specified, resulting in an invalid `package.json`.