### PR TITLE
[ENHANCEMENT] eslint - change iife style to inside

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@
     "no-multiple-empty-lines"          : [2, {"max": 2}],
     "quotes"                           : [2, "single"],
     "eqeqeq"                           : [2, "smart"],
-    "wrap-iife"                        : [2, "outside"],
+    "wrap-iife"                        : [2, "inside"],
     "indent"                           : [2, 2],
     "brace-style"                      : [2, "1tbs"],
     "spaced-line-comment"              : [2, "always", {"exceptions":["-","+"]}],


### PR DESCRIPTION
Change eslint rules to accept:

```
var x = (function () { return { y: 1 };})();
```

instead of:

```
var x = (function () { return { y: 1 };}());
```

Which improves the ability to recognize statement as an iife at a glance.