### PR TITLE
[ENHANCEMENT] Use local ember-cli when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [ENHANCEMENT] Added [eslint](http://eslint.org/) through [mocha-eslint](https://github.com/BadgeLabs/mocha-eslint)
 * [BUGFIX] Fixed docker root issue for linux
 * [ENHANCEMENT] Added stack trace to errors in `sane new`
+* [ENHANCEMENT] Default to using local (SANE installed) ember-cli when possible.
 
 ### 0.0.24
 * [FEATURE] Added autoreload of sails server using [sails-hook-autoreload](https://github.com/sgress454/sails-hook-autoreload) hook

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ install:
   - md C:\nc
   - npm config set cache C:\nc
   - npm install -g sails
+  - npm install -g ember-cli
   - npm install
 
 # Post-install test scripts.

--- a/lib/helpers/ember.js
+++ b/lib/helpers/ember.js
@@ -1,23 +1,42 @@
 'use strict';
 
-var path = require('path');
-var fs   = require('fs-extra');
+var path      = require('path');
+var fs        = require('fs-extra');
+var { spawn } = require('child_process');
 
-var localEmber = path.join(process.cwd(), 'client', 'node_modules', 'ember-cli', 'bin', (process.platform === 'win32' ? 'ember.cmd' : 'ember'));
-var ember;
 
-// Try to use the locally installed ember-cli first
-if (fs.existsSync(localEmber)) {
-  ember = localEmber;
-} else {
+var ember = (function determineEmber() {
+  // Try to use the locally installed ember-cli first
+  var localEmber = path.join(process.cwd(), 'client', 'node_modules', 'ember-cli', 'bin',
+    (process.platform === 'win32' ? 'ember.cmd' : 'ember'));
+  if (fs.existsSync(localEmber)) {
+    return localEmber;
+  }
+
+  // Windows is a bit special, since it requires an npm-generated .cmd file,
+  // and as such, cannot use the local version inside node_modules
+  if (process.platform === 'win32') {
+    // Spawn an `ember.cmd --version`, just to see if it is installed
+    try {
+      spawn('ember.cmd', ['version'], { stdio: 'ignore' });
+    } catch(err) {
+      throw new Error('ember-cli is not installed, please run "npm install -g ember-cli"');
+    }
+    return 'ember.cmd';
+  }
+
   // Try to resolve a globally installed ember-cli and use that
   try {
-    var globalCliPath = require.resolve('ember-cli');
-    var globalPath = globalCliPath.replace(/\/lib\/cli\/index\.js$/, '');
+    // require.resolve returns `lib/cli/index.js`
+    var globalPath = path.join(
+      require.resolve('ember-cli')
+      .replace(/\/lib\/cli\/index\.js$/, ''),
+      'bin',
+      'ember');
   } catch(err) {
-    throw new Error('global ember-cli not installed, please run "npm install -g ember-cli"');
+    throw new Error('ember-cli is not installed, please run "npm install -g ember-cli"');
   }
-  ember = path.join(globalPath, 'bin', (process.platform === 'win32' ? 'ember.cmd' : 'ember'));
-}
+  return globalPath;
+})();
 
 module.exports = ember;

--- a/lib/helpers/ember.js
+++ b/lib/helpers/ember.js
@@ -1,5 +1,23 @@
 'use strict';
 
-var ember = (process.platform === 'win32' ? 'ember.cmd' : 'ember');
+var path = require('path');
+var fs   = require('fs-extra');
+
+var localEmber = path.join(process.cwd(), 'client', 'node_modules', 'ember-cli', 'bin', (process.platform === 'win32' ? 'ember.cmd' : 'ember'));
+var ember;
+
+// Try to use the locally installed ember-cli first
+if (fs.existsSync(localEmber)) {
+  ember = localEmber;
+} else {
+  // Try to resolve a globally installed ember-cli and use that
+  try {
+    var globalCliPath = require.resolve('ember-cli');
+    var globalPath = globalCliPath.replace(/\/lib\/cli\/index\.js$/, '');
+  } catch(err) {
+    throw new Error('global ember-cli not installed, please run "npm install -g ember-cli"');
+  }
+  ember = path.join(globalPath, 'bin', (process.platform === 'win32' ? 'ember.cmd' : 'ember'));
+}
 
 module.exports = ember;


### PR DESCRIPTION
Fixes #111

If there is a locally installed version of ember-cli (in the client directory, after npm install is run), then use that. Otherwise, try to use some kind of globally installed ember-cli.

On Windows, the global module needs to be installed by npm, otherwise there is no .cmd batch file for Windows to execute.

On other platforms, the location can be determined by using require.resolve and then doing a little path manipulation.

I hope to hear some good suggestions how this could be cleaned up, because I don't think it's the clearest code possible, and maybe there are better ways to do this that I don't know about. Also, not sure how to go about writing any tests for these changes. Any ideas would be much appreciated.