### PR TITLE
[ENHANCEMENT] Use local ember-cli when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [BUGFIX] Fixed docker root issue for linux
 * [ENHANCEMENT] Added stack trace to errors in `sane new`
 * [ENHANCEMENT] Use master version of [sails-hook-dev](https://github.com/balderdashy/sails-hook-dev) since `1.0.0` runs into issues on Linux
+* [BUGFIX] Enabled SANE to run without requiring a global ember-cli installation.
 
 ### 0.0.24
 * [FEATURE] Added autoreload of sails server using [sails-hook-autoreload](https://github.com/sgress454/sails-hook-autoreload) hook

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   # Typical npm stuff.
   - md C:\nc
   - npm config set cache C:\nc
-  - npm install -g sails
+  - npm install -g sails ember-cli
   - npm install
 
 # Post-install test scripts.

--- a/lib/helpers/ember.js
+++ b/lib/helpers/ember.js
@@ -1,5 +1,6 @@
 'use strict';
 
-var ember = (process.platform === 'win32' ? 'ember.cmd' : 'ember');
+var which = require('npm-which')(process.cwd());
 
-module.exports = ember;
+
+module.exports = which.sync('ember');

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "handlebars": "~3.0.0",
     "leek": "0.0.18",
     "node-uuid": "^1.4.2",
+    "npm-which": "^2.0.0",
     "pleasant-progress": "^1.0.2",
     "readline-sync": "^0.7.3",
     "resolve": "^1.0.0",

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -4,18 +4,18 @@
 var glob  = require('glob');
 var Mocha = require('mocha');
 var chalk = require('chalk');
-
+var root;
 
 require('traceur').require.makeDefault(function (filename) {
 // don't transpile our dependencies, just our app
-//The first check is if you develop locally, the second for the globally installed moduel
+// The first check is if you develop locally, the second for the globally installed moduel
   return (filename.indexOf('node_modules') === -1) ||
     (filename.indexOf('/node_modules/sane-cli/') > -1 && filename.indexOf('/node_modules/sane-cli/node_modules') === -1);
 }, {asyncFunctions: true});
 
 var mocha = new Mocha({
   // For some reason, tests take a long time on Windows (or at least AppVeyor)
-  timeout: (process.platform === 'win32') ? 90000 : 18000,
+  timeout : (process.platform === 'win32') ? 90000 : 18000,
   reporter: 'spec'
 });
 
@@ -26,7 +26,7 @@ if (!arg) {
 } else if (arg === 'unit') {
   var root = 'tests/unit';
 } else {
-  var root = 'tests/{unit,acceptance}';
+  root = 'tests/{unit,acceptance}';
 }
 
 function addFiles(mocha, files) {

--- a/tests/unit/helpers/emberTest.js
+++ b/tests/unit/helpers/emberTest.js
@@ -1,0 +1,17 @@
+/*eslint-env node, mocha, es6 */
+'use strict';
+
+var ember = require('../../../lib/helpers/ember');
+var expect = require('chai').expect;
+
+describe('Unit: ember helper', function () {
+
+  it('returns a value', function () {
+    expect(ember).to.be.ok();
+  });
+
+  it('returns local ember by default', function () {
+    expect(ember).to.match(/sane[\/\\]node_modules[\/\\]\.bin[\/\\]ember(.CMD)?$/);
+  });
+
+});


### PR DESCRIPTION
Fixes #111

If there is a locally installed version of ember-cli (in the client directory, after npm install is run), then use that. Otherwise, try to use some kind of globally installed ember-cli.

On Windows, the global module needs to be installed by npm, otherwise there is no .cmd batch file for Windows to execute.

On other platforms, the location can be determined by using require.resolve and then doing a little path manipulation.

Includes initial rudimentary tests, but more should be added.