### PR TITLE
[ENHANCEMENT] Add 'key-spacing' ESLint Rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
     "no-cond-assign"                   : 2,
     "space-after-keywords"             : 2,
     "space-infix-ops"                  : 2,
+    "key-spacing"                      : [2, {"align": "colon"}],
     "comma-dangle"                     : [2, "never"],
     "no-multiple-empty-lines"          : [2, {"max": 2}],
     "quotes"                           : [2, "single"],

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -72,11 +72,11 @@ function prepareDockerTemplate(name, option, user) {
   }
 
   return prepareTemplate(name, {
-    database: db,
-    port: port,
-    isMysql: isMysql,
+    database  : db,
+    port      : port,
+    isMysql   : isMysql,
     serverName: serverName,
-    user: dockerUser
+    user      : dockerUser
   });
 }
 

--- a/lib/helpers/setUpTracking.js
+++ b/lib/helpers/setUpTracking.js
@@ -19,10 +19,10 @@ module.exports = function setUpTracking(trackingCode, name, version, config) {
   //setup analytics
   var leekOptions = {
     trackingCode: trackingCode,
-    globalName: name,
-    name: clientId(),
-    version: version,
-    silent: config.disableAnalytics || false
+    globalName  : name,
+    name        : clientId(),
+    version     : version,
+    silent      : config.disableAnalytics || false
   };
 
   return new Leek(leekOptions);

--- a/lib/tasks/trackCommand.js
+++ b/lib/tasks/trackCommand.js
@@ -18,7 +18,7 @@ module.exports = function trackCommand(name, options, leek) {
   name = `${name} ${optionString}`;
 
   leek.track({
-    name: 'sane ',
+    name   : 'sane ',
     message: name
   });
 };

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "babel-eslint": "^2.0.2",
     "chai": "^1.9.1",
     "chai-as-promised": "^4.1.1",
-    "eslint": "^0.16.2",
+    "eslint": "^0.20.0",
     "glob": "4.0.5",
     "lodash": "^3.6.0",
     "mocha": "^2.0.1",

--- a/tests/helpers/runCommand.js
+++ b/tests/helpers/runCommand.js
@@ -48,7 +48,7 @@ module.exports = function run(/* command, args, options */) {
     var result = {
       output: [],
       errors: [],
-      code: null
+      code  : null
     };
 
     if (options.onChildSpawned) {


### PR DESCRIPTION
As of ESLint 0.20.0, the `align` option of `key-spacing` does not impact single-line object literals.  So now it is possible to add this rule and when object literals are broken into multiple lines, enforce an alignment.