### PR TITLE
[BUGFIX] Use SANE's ember if no global ember exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # SANE Stack Changelog
 
+### Master
+* [BUGFIX] No longer requires global ember-cli
+
 ### 0.1.0-beta.1
 * [FEATURE] Added an `sane install` command that allows to install addons such as `sane install sane-auth`. More details on how to write addons comming soon! In the mean-time check out https://github.com/sane/sane-auth/
 * [BREAKING BUGFIX] Only supports ember-cli 0.2.3 and above for the addon system

--- a/lib/helpers/ember.js
+++ b/lib/helpers/ember.js
@@ -1,5 +1,16 @@
 'use strict';
 
+var ember;
+var path = require('path');
+var emberBin = process.platform === 'win32' ? 'ember.cmd' : 'ember';
+var localEmber = path.join(__dirname, '..', '..', 'node_modules', '.bin', emberBin);
+var checkEnvironment = require('../tasks/checkEnvironment');
 var which = require('npm-which')(process.cwd());
 
-module.exports = which.sync('ember');
+if (!checkEnvironment.emberExists()) {
+  ember = localEmber;
+} else {
+  ember = which.sync('ember');
+}
+
+module.exports = ember;

--- a/src/helpers/ember.js
+++ b/src/helpers/ember.js
@@ -3,7 +3,7 @@
 var ember;
 var path             = require('path');
 var emberBin         = (process.platform === 'win32' ? 'ember.cmd' : 'ember');
-var localEmber       = path.normalize(path.join(__dirname, '..', '..', 'node_modules', '.bin', emberBin));
+var localEmber       = path.join(__dirname, '..', '..', 'node_modules', '.bin', emberBin);
 var checkEnvironment = require('../tasks/checkEnvironment');
 var which            = require('npm-which')(process.cwd());
 

--- a/src/helpers/ember.js
+++ b/src/helpers/ember.js
@@ -3,7 +3,7 @@
 var ember;
 var path             = require('path');
 var emberBin         = (process.platform === 'win32' ? 'ember.cmd' : 'ember');
-var localEmber       = path.join(__dirname, '..', '..', 'node_modules', '.bin', emberBin);
+var localEmber       = path.normalize(path.join(__dirname, '..', '..', 'node_modules', '.bin', emberBin));
 var checkEnvironment = require('../tasks/checkEnvironment');
 var which            = require('npm-which')(process.cwd());
 

--- a/src/helpers/ember.js
+++ b/src/helpers/ember.js
@@ -1,6 +1,16 @@
 'use strict';
 
-var which = require('npm-which')(process.cwd());
+var ember;
+var path             = require('path');
+var emberBin         = (process.platform === 'win32' ? 'ember.cmd' : 'ember');
+var localEmber       = path.join(__dirname, '..', '..', 'node_modules', '.bin', emberBin);
+var checkEnvironment = require('../tasks/checkEnvironment');
+var which            = require('npm-which')(process.cwd());
 
+if (!checkEnvironment.emberExists()) {
+  ember = localEmber;
+} else {
+  ember = which.sync('ember');
+}
 
-module.exports = which.sync('ember');
+module.exports = ember;

--- a/tests/unit/helpers/emberTest.js
+++ b/tests/unit/helpers/emberTest.js
@@ -10,7 +10,7 @@ describe('Unit: ember helper', function () {
   });
 
   it('returns local ember by default', function () {
-    expect(ember).to.match(/sane[\/\\]node_modules[\/\\]\.bin[\/\\]ember(.CMD)?$/);
+    expect(ember).to.match(/sane[\/(\\)*]node_modules[\/(\\)*]\.bin[\/(\\)*]ember(.CMD)?$/);
   });
 
 });

--- a/tests/unit/helpers/emberTest.js
+++ b/tests/unit/helpers/emberTest.js
@@ -10,7 +10,7 @@ describe('Unit: ember helper', function () {
   });
 
   it('returns local ember by default', function () {
-    expect(ember).to.match(/sane[\/(\\)*]node_modules[\/(\\)*]\.bin[\/(\\)*]ember(.CMD)?$/);
+    expect(ember).to.match(/sane[\/\\]*node_modules[\/\\]*\.bin[\/\\]*ember(.cmd)?$/);
   });
 
 });


### PR DESCRIPTION
Previously, the ember helper (`src/helpers/ember.js`) would use the ember-cli closest to the
process.cwd, and if it couldn't find one in the current project, it would
use a global ember-cli.

The problem is that upon first installation of sane-cli, unless ember-cli
was also installed, the helper could not resolve a version of ember unless `sane` was
invoked inside the sane project.  This meant that commands like `sane new .` and even
`sane --help` would fail with `Error: not found: ember`.

The changes here will cause the ember helper to use the ember-cli within node_modules of
the globally installed sane-cli if it is determined that ember-cli is not installed globally on the 
user's machine, using code very similar to that in `commands/new.js`.

With this commit in place, installing `ember-cli` globally should no longer be necessary.