### PR TITLE
[ENHANCEMENT] Run Travis against io.js 1.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 node_js:
   - "0.12"
   - "iojs"
+  - "iojs-v1.8.1"
 before_install:
   - npm config set spin false
   - npm install -g sails


### PR DESCRIPTION
Should run Travis against io.js 1.x branch as well as latest (currently 2.x).