### PR TITLE
[BUGFIX] Change method of getting global ember-cli version

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -184,7 +184,7 @@ function cleanUpSails(options, silent) {
 }
 
 module.exports = function newProject(name, options, leek) {
-  var ember, localEmber, localEmberVersion, semVer, emberVersion, answer, installMsg, silent, projectName, prepareOptions, resetDockerUser, cliConfig, opt, sailsVersion, sailsPackages, emberArgs, templates, templatesRoot, i, templateInPath, templateOutPath, host, pollingWatch;
+  var ember, localEmber, localEmberVersion, emberVersion, answer, installMsg, silent, projectName, prepareOptions, resetDockerUser, cliConfig, opt, sailsVersion, sailsPackages, emberArgs, templates, templatesRoot, i, templateInPath, templateOutPath, host, pollingWatch;
   return regeneratorRuntime.async(function newProject$(context$1$0) {
     while (1) switch (context$1$0.prev = context$1$0.next) {
       case 0:
@@ -198,20 +198,18 @@ module.exports = function newProject(name, options, leek) {
         }
 
         ember = localEmber;
-        context$1$0.next = 12;
+        context$1$0.next = 11;
         break;
 
       case 7:
-        semVer = new RegExp(/([0-9]+.[0-9]+.[0-9]+)(\-beta.[0-9])?/);
-        context$1$0.next = 10;
-        return spawn(ember, ['version'], { capture: ['stdout'] }).then(function (result) {
-          //  Get the first version number that the global ember spits out.
-          return result.stdout.match(semVer)[0];
+        context$1$0.next = 9;
+        return spawn(npm, ['ls', '--global', '--json', '--depth=0', 'ember-cli'], { capture: ['stdout'] }).then(function (result) {
+          return result.dependencies['ember-cli'].version;
         }, function (err) {
-          console.log(err);
+          console.error(err);
         });
 
-      case 10:
+      case 9:
         emberVersion = context$1$0.sent;
 
         // compare the different ember versions
@@ -223,52 +221,52 @@ module.exports = function newProject(name, options, leek) {
           }
         }
 
-      case 12:
+      case 11:
         if (!options.docker) {
-          context$1$0.next = 20;
+          context$1$0.next = 19;
           break;
         }
 
         installMsg = 'Setting up Sails project and downloading latest Docker Containers.';
 
         if (checkEnvironment.dockerExists()) {
-          context$1$0.next = 16;
+          context$1$0.next = 15;
           break;
         }
 
         throw new Error('sane requires the latest docker/boot2docker/docker-compose to be installed. ' + 'Check https://github.com/artificialio/sane/blob/master/README.md for more details.');
 
-      case 16:
+      case 15:
         if (checkEnvironment.isDockerRunning()) {
-          context$1$0.next = 18;
+          context$1$0.next = 17;
           break;
         }
 
         throw new Error('Make sure your docker/boot2docker is running');
 
-      case 18:
-        context$1$0.next = 23;
+      case 17:
+        context$1$0.next = 22;
         break;
 
-      case 20:
+      case 19:
         installMsg = 'Setting up Sails project locally.';
 
         if (checkEnvironment.sailsExists()) {
-          context$1$0.next = 23;
+          context$1$0.next = 22;
           break;
         }
 
         throw new Error('sane requires the latest sails to be installed. Run npm install -g sails.');
 
-      case 23:
+      case 22:
         if (!isWrongProjectName(name)) {
-          context$1$0.next = 25;
+          context$1$0.next = 24;
           break;
         }
 
         throw new Error('Sane currently does not support a projectname of \'' + name + '\'.');
 
-      case 25:
+      case 24:
 
         options.database = normalizeOption(options.database);
         silent = true;
@@ -286,34 +284,34 @@ module.exports = function newProject(name, options, leek) {
         console.log('Sane version: ' + projectMeta.version() + '\n');
 
         if (!(name !== '.')) {
-          context$1$0.next = 44;
+          context$1$0.next = 43;
           break;
         }
 
-        context$1$0.prev = 31;
+        context$1$0.prev = 30;
 
         fs.mkdirSync(name);
         // change directory into projectRoot
         process.chdir(name);
-        context$1$0.next = 44;
+        context$1$0.next = 43;
         break;
 
-      case 36:
-        context$1$0.prev = 36;
-        context$1$0.t4 = context$1$0['catch'](31);
+      case 35:
+        context$1$0.prev = 35;
+        context$1$0.t4 = context$1$0['catch'](30);
 
         if (!(context$1$0.t4.code === 'EEXIST')) {
-          context$1$0.next = 43;
+          context$1$0.next = 42;
           break;
         }
 
         context$1$0.t4.message = 'Creating a new folder failed. Check if the folder \'' + name + '\' already exists.';
         throw context$1$0.t4;
 
-      case 43:
+      case 42:
         throw context$1$0.t4;
 
-      case 44:
+      case 43:
         projectName = path.basename(process.cwd());
         prepareOptions = null;
         resetDockerUser = false;
@@ -340,68 +338,68 @@ module.exports = function newProject(name, options, leek) {
 
         // creating a default .sane-cli based on the parameters used in the new command
         fs.writeFileSync(path.join('.sane-cli'), JSON.stringify(cliConfig, null, 2));
-        context$1$0.prev = 53;
+        context$1$0.prev = 52;
 
         fs.mkdirSync(serverName);
-        context$1$0.next = 65;
+        context$1$0.next = 64;
         break;
 
-      case 57:
-        context$1$0.prev = 57;
-        context$1$0.t5 = context$1$0['catch'](53);
+      case 56:
+        context$1$0.prev = 56;
+        context$1$0.t5 = context$1$0['catch'](52);
 
         if (!(context$1$0.t5.code === 'EEXIST')) {
-          context$1$0.next = 64;
+          context$1$0.next = 63;
           break;
         }
 
         context$1$0.t5.message = 'Creating a new folder failed. Check if the folder \'' + name + '\' already exists.';
         throw context$1$0.t5;
 
-      case 64:
+      case 63:
         throw context$1$0.t5;
 
-      case 65:
+      case 64:
 
         // TODO(markus): If we use spawn with stdio inherit we can print the proper output for fog
         // should also fix the ember-cli output
         console.log(chalk.green(installMsg));
 
         if (options.docker) {
-          context$1$0.next = 72;
+          context$1$0.next = 71;
           break;
         }
 
-        context$1$0.next = 69;
+        context$1$0.next = 68;
         return spawn(sails, ['version'], { capture: ['stdout'] }).then(function (result) {
           return result.stdout.toString();
         }, function (err) {
           console.log(err);
         });
 
-      case 69:
+      case 68:
         sailsVersion = context$1$0.sent;
-        context$1$0.next = 75;
+        context$1$0.next = 74;
         break;
 
-      case 72:
-        context$1$0.next = 74;
+      case 71:
+        context$1$0.next = 73;
         return spawn(dockerCompose, ['run', 'server', 'sails', 'version'], { capture: ['stdout'] }).then(function (result) {
           return result.stdout.toString();
         }, function (err) {
           console.log(err);
         });
 
-      case 74:
+      case 73:
         sailsVersion = context$1$0.sent;
 
-      case 75:
+      case 74:
         process.stdout.write('sails version: ' + sailsVersion);
 
-        context$1$0.next = 78;
+        context$1$0.next = 77;
         return dockerExec('sails new .', options.docker);
 
-      case 78:
+      case 77:
 
         if (!options.skipNpm) {
           progress.start(chalk.green('Installing Sails packages for tooling via npm.'));
@@ -413,14 +411,14 @@ module.exports = function newProject(name, options, leek) {
         }
 
         sailsPackages = ['sails-generate-ember-blueprints', 'lodash', 'pluralize', 'sails-hook-autoreload@~0.11.4', 'sails-hook-dev@balderdashy/sails-hook-dev', 'sails-' + options.database];
-        context$1$0.next = 83;
+        context$1$0.next = 82;
         return dockerExec('npm i ' + sailsPackages.join(' ') + ' --save', options.docker, silent, options.skipNpm);
 
-      case 83:
-        context$1$0.next = 85;
+      case 82:
+        context$1$0.next = 84;
         return dockerExec('sails generate ember-blueprints', options.docker, silent, options.skipNpm);
 
-      case 85:
+      case 84:
 
         if (!options.skipNpm) {
           progress.stop();
@@ -444,10 +442,10 @@ module.exports = function newProject(name, options, leek) {
         }
 
         process.stdout.write('ember-cli ');
-        context$1$0.next = 93;
+        context$1$0.next = 92;
         return spawn(ember, emberArgs, { stdio: 'inherit' });
 
-      case 93:
+      case 92:
 
         progress.start(chalk.green('Running tooling scrips for Sane.'));
 
@@ -480,65 +478,57 @@ module.exports = function newProject(name, options, leek) {
           }
         }
 
-        context$1$0.prev = 98;
-        context$1$0.next = 101;
+        context$1$0.prev = 97;
+        context$1$0.next = 100;
         return cleanUpSails(options, silent);
 
-      case 101:
-        context$1$0.next = 107;
+      case 100:
+        context$1$0.next = 106;
         break;
 
-      case 103:
-        context$1$0.prev = 103;
-        context$1$0.t6 = context$1$0['catch'](98);
+      case 102:
+        context$1$0.prev = 102;
+        context$1$0.t6 = context$1$0['catch'](97);
 
         console.log('Cleaning up Sails had some erros. Relax, your app is still working perfectly and shiny.');
         log.verbose('Error Message to report:', context$1$0.t6);
 
-      case 107:
+      case 106:
         if (options.skipNpm) {
-          context$1$0.next = 117;
+          context$1$0.next = 116;
           break;
         }
 
-        context$1$0.prev = 108;
-        context$1$0.next = 111;
+        context$1$0.prev = 107;
+        context$1$0.next = 110;
         return spawn(npm, ['install']);
 
-      case 111:
-        context$1$0.next = 117;
+      case 110:
+        context$1$0.next = 116;
         break;
 
-      case 113:
-        context$1$0.prev = 113;
-        context$1$0.t7 = context$1$0['catch'](108);
+      case 112:
+        context$1$0.prev = 112;
+        context$1$0.t7 = context$1$0['catch'](107);
 
         console.log('Could not install local sane-cli. Manuall run \'npm install\' and all should be fine.');
         log.verbose('Error Message to report:', context$1$0.t7);
 
-      case 117:
+      case 116:
 
         progress.stop();
         console.log(chalk.green('Sane Project \'' + projectName + '\' successfully created.'));
 
-      case 119:
+      case 118:
       case 'end':
         return context$1$0.stop();
     }
-  }, null, this, [[31, 36], [53, 57], [98, 103], [108, 113]]);
+  }, null, this, [[30, 35], [52, 56], [97, 102], [107, 112]]);
 };
 
-// use global ember-cli if exists, otherwise the local one
-// TODO(markus): If global version differs from local one, then ask which one to use
+// take the local ember version from the package.json.
 
-// take the local ember version from the package.json. Much faster
-
-// regex to get semantic version string including beta version
-
-// Note(markus): Somehow do not seem to be able to get access to the globally installed ember-cli package.json
-// var globalEmber = path.relative(process.cwd(), path.join(exec('npm root -g', { silent: true }).output, 'ember-cli', 'package.json'));
-// var emberVersion = require(globalEmber).version;
-// We could also try npm ls -g --depth=0. But for some reason the commands exits with error code 1 for me.
+// Get globally installed ember version
 
 // --docker is set
 // If . is passed it creates a new project in the current folder

--- a/lib/tasks/checkEnvironment.js
+++ b/lib/tasks/checkEnvironment.js
@@ -71,7 +71,7 @@ var self = {
 
   emberExists: function emberExists() {
     try {
-      which('ember');
+      execSync('npm', ['ls', '--global', '--depth=0', 'ember-cli']);
       return true;
     } catch (err) {
       return false;

--- a/src/tasks/checkEnvironment.js
+++ b/src/tasks/checkEnvironment.js
@@ -68,7 +68,7 @@ var self = {
 
   emberExists: function () {
     try {
-      which('ember');
+      execSync('npm', ['ls', '--global', '--depth=0', 'ember-cli']);
       return true;
     } catch (err) {
       return false;


### PR DESCRIPTION
Use npm ls instead of which to find ember and `ember -v` output parsing to find ember version.

Travis puts `/home/travis/build/artificialio/sane/node_modules/.bin/ember` into the PATH env variable, so it looks like ember is globally installed, when it is actually just the version inside sane.

This change uses `npm ls --global --depth=0 ember-cli` to look for a globally installed ember, which will return an exit code of 1 if it isn't found.